### PR TITLE
Fix for rendering pretty fragments

### DIFF
--- a/dexml/__init__.py
+++ b/dexml/__init__.py
@@ -412,6 +412,13 @@ class Model(object):
         xml = "".join(data)
         if pretty:
             xml = minidom.parseString(xml).toprettyxml()
+            if fragment:
+                # Since the `fragment` flag is set, we assume that the user
+                # wants the header removed no matter what.
+                # Hack for removing the `<?xml version="1.0"?>` header that
+                # minidom adds when pretty printing.
+                line_break_position = xml.find('\n') + 1
+                xml = xml[line_break_position:]
         if encoding:
             xml = xml.encode(encoding)
         return xml

--- a/dexml/__init__.py
+++ b/dexml/__init__.py
@@ -68,7 +68,7 @@ __ver_minor__ = 5
 __ver_patch__ = 1
 __ver_sub__ = ""
 __version__ = "%d.%d.%d%s" % (__ver_major__,__ver_minor__,__ver_patch__,__ver_sub__)
-                              
+
 
 import sys
 import re
@@ -402,23 +402,26 @@ class Model(object):
         if nsmap is None:
             nsmap = {}
         data = []
+        header = '<?xml version="1.0" ?>'
+        if encoding:
+            header = '<?xml version="1.0" encoding="%s" ?>' % (encoding,)
         if not fragment:
-            if encoding:
-                s = '<?xml version="1.0" encoding="%s" ?>' % (encoding,)
-                data.append(s)
-            else:
-                data.append('<?xml version="1.0" ?>')
+            data.append(header)
+
         data.extend(self._render(nsmap))
         xml = "".join(data)
         if pretty:
             xml = minidom.parseString(xml).toprettyxml()
+            # Hack for removing the `<?xml version="1.0"?>` header that
+            # minidom adds when pretty printing.
+            line_break_position = xml.find('\n') + 1
+            headless_xml = xml[line_break_position:]
             if fragment:
-                # Since the `fragment` flag is set, we assume that the user
-                # wants the header removed no matter what.
-                # Hack for removing the `<?xml version="1.0"?>` header that
-                # minidom adds when pretty printing.
-                line_break_position = xml.find('\n') + 1
-                xml = xml[line_break_position:]
+                xml = headless_xml
+            elif encoding:
+                # Minidom also removes the header (or just the `encoding` key)
+                # if it is present
+                xml = header + '\n' + headless_xml
         if encoding:
             xml = xml.encode(encoding)
         return xml

--- a/dexml/test.py
+++ b/dexml/test.py
@@ -101,8 +101,12 @@ class TestDexml(unittest.TestCase):
         h = hello()
         self.assertEquals(h.render(),'<?xml version="1.0" ?><hello />')
         self.assertEquals(h.render(fragment=True),"<hello />")
+        self.assertEquals(h.render(pretty=True), '<?xml version="1.0" ?>\n<hello/>\n')
+        self.assertEquals(h.render(fragment=True, pretty=True), "<hello/>\n")
+        self.assertEquals(h.render(encoding="utf8", pretty=True), b('<?xml version="1.0" encoding="utf8" ?>\n<hello/>\n'))
         self.assertEquals(h.render(encoding="utf8"),b('<?xml version="1.0" encoding="utf8" ?><hello />'))
         self.assertEquals(h.render(encoding="utf8",fragment=True),b("<hello />"))
+        self.assertEquals(h.render(encoding="utf8", fragment=True, pretty=True), b("<hello/>\n"))
 
         self.assertEquals(h.render(),"".join(h.irender()))
         self.assertEquals(h.render(fragment=True),"".join(h.irender(fragment=True)))

--- a/dexml/test.py
+++ b/dexml/test.py
@@ -103,8 +103,8 @@ class TestDexml(unittest.TestCase):
         self.assertEquals(h.render(fragment=True),"<hello />")
         self.assertEquals(h.render(pretty=True), '<?xml version="1.0" ?>\n<hello/>\n')
         self.assertEquals(h.render(fragment=True, pretty=True), "<hello/>\n")
-        self.assertEquals(h.render(encoding="utf8", pretty=True), b('<?xml version="1.0" encoding="utf8" ?>\n<hello/>\n'))
         self.assertEquals(h.render(encoding="utf8"),b('<?xml version="1.0" encoding="utf8" ?><hello />'))
+        self.assertEquals(h.render(encoding="utf8", pretty=True), b('<?xml version="1.0" encoding="utf8" ?>\n<hello/>\n'))
         self.assertEquals(h.render(encoding="utf8",fragment=True),b("<hello />"))
         self.assertEquals(h.render(encoding="utf8", fragment=True, pretty=True), b("<hello/>\n"))
 


### PR DESCRIPTION
minidom toprettyxml adds <?xml version="1.0"?> to the output, but it doesn't make sense to fragments.