### PR TITLE
Revert ability to do fields.Model(tagname='foo')

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,9 @@
 
+Pending
+
+  * Revert ability to specify 'tagname' on a fields.Model.
+
+
 v0.5.1
 
   * Handle list tagnames, and field tagnames within a list.

--- a/dexml/fields.py
+++ b/dexml/fields.py
@@ -98,7 +98,7 @@ class Field(object):
         """Render any attributes that this field manages."""
         return []
 
-    def render_children(self,obj,nsmap,val):
+    def render_children(self,obj,val,nsmap):
         """Render any child nodes that this field manages."""
         return []
 
@@ -589,8 +589,6 @@ class List(Field):
                 if self.maxlength is not None and num_items > self.maxlength:
                     msg = "Field '%s': too many items" % (self.field_name,)
                     raise dexml.RenderError(msg)
-                if hasattr(item, "meta") and self.field.tagname:
-                    item.meta.tagname = self.field.tagname
                 for data in self.field.render_children(obj,item,nsmap):
                     yield data
             if self.minlength is not None and num_items < self.minlength:

--- a/dexml/test.py
+++ b/dexml/test.py
@@ -1033,7 +1033,7 @@ class TestDexml(unittest.TestCase):
 class TestListField(unittest.TestCase):
     class F(dexml.Model):
         class meta:
-            tagname = 'f'
+            tagname = "f"
         name = fields.String(tagname="name")
 
     def test_empty(self):
@@ -1067,19 +1067,24 @@ class TestListField(unittest.TestCase):
         self.assertEqual(o.render(fragment=True), "<obj><L><f><name>N1</name></f></L></obj>")
 
     def test_model_tagname(self):
+        class FF(self.F):
+            pass
         class obj(dexml.Model):
-            fs = fields.List(fields.Model(self.F, tagname="FF"))
+            fs = fields.List(fields.Model(FF))
 
         o = obj()
-        o.fs.append(self.F(name="N1"))
+        o.fs.append(FF(name="N1"))
         self.assertEqual(o.render(fragment=True), "<obj><FF><name>N1</name></FF></obj>")
 
     def test_list_and_model_tagnames(self):
+        class FF(self.F):
+            class meta:
+                tagname = "FF"
         class obj(dexml.Model):
-            fs = fields.List(fields.Model(self.F, tagname="FF"), tagname="L")
+            fs = fields.List(fields.Model(FF), tagname="L")
 
         o = obj()
-        o.fs.append(self.F(name="N1"))
+        o.fs.append(FF(name="N1"))
         self.assertEqual(o.render(fragment=True), "<obj><L><FF><name>N1</name></FF></L></obj>")
 
     def test_strings(self):


### PR DESCRIPTION
This reverts part of #15, removing the attempt to make model fields have custom tagnames like:

```
  class F(dexml.Model)
    name = fields.String(tagname="name")

  class obj(dexml.Model):
    fs = fields.List(fields.Model(F, tagname="FF"))
```

IIUC the idea what that this would cause an `F` model to be rendered with an alternative tag name of `FF`.  But the implementation relied on changing the metadata of `F` at runtime, and seemed to produce test bustage.   We already have a way of changing the tagname of a model by subclassing:

```
  class FF(F)
    pass

  class obj(dexml.Model):
    fs = fields.List(fields.Model(FF))
```

So I'm backing out the alternative syntax.

@iurisilvio I'm happy to consider adding `fields.Model(F, tagname="FF")` back in if you can say more about why you prefer it over the above form.